### PR TITLE
Fix inheritence to make sure parse function is available

### DIFF
--- a/lib/AqaraPlatform.js
+++ b/lib/AqaraPlatform.js
@@ -120,7 +120,7 @@ AqaraPlatform.prototype.startServer = function() {
 // Parse message which is sent from Aqara gateways
 AqaraPlatform.prototype.parseMessage = function(msg, rinfo){
   var platform = this;
-  // platform.log.debug('recv %s(%d bytes) from client %s:%d\n', msg, msg.length, rinfo.address, rinfo.port);
+  platform.log.debug('recv %s(%d bytes) from client %s:%d\n', msg, msg.length, rinfo.address, rinfo.port);
   var json;
   try {
     json = JSON.parse(msg);
@@ -200,6 +200,8 @@ TemperatureAndHumidityParser = function(platform) {
   this.init(platform);
 }
 
+inherits(TemperatureAndHumidityParser, BaseParser);
+
 TemperatureAndHumidityParser.prototype.parse = function(report) {
   var deviceSid = report['sid'];
   var gatewaySid = this.platform.gatewaySids[deviceSid];
@@ -210,12 +212,12 @@ TemperatureAndHumidityParser.prototype.parse = function(report) {
   this.factory.setTemperatureAndHumidity(gatewaySid, deviceSid, temperature, humidity);
 }
 
-inherits(TemperatureAndHumidityParser, BaseParser);
-
 // Motion sensor data parser
 MotionParser = function(platform) {
   this.init(platform);
 }
+
+inherits(MotionParser, BaseParser);
 
 MotionParser.prototype.parse = function(report, rinfo) {
   var deviceSid = report['sid'];
@@ -226,12 +228,13 @@ MotionParser.prototype.parse = function(report, rinfo) {
   this.factory.setMotion(gatewaySid, deviceSid, motionDetected);
 }
 
-inherits(MotionParser, BaseParser);
 
 // Contact/Magnet sensor data parser
 ContactParser = function(platform) {
   this.init(platform);
 }
+
+inherits(ContactParser, BaseParser);
 
 ContactParser.prototype.parse = function(report, rinfo) {
   var deviceSid = report['sid'];
@@ -242,13 +245,13 @@ ContactParser.prototype.parse = function(report, rinfo) {
   this.factory.setContact(gatewaySid, deviceSid, contacted);
 }
 
-inherits(ContactParser, BaseParser);
-
 // Light switch data parser
 LightSwitchParser = function(platform) {
   this.init(platform);
   this.commanders = {};
 }
+
+inherits(LightSwitchParser, BaseParser);
 
 LightSwitchParser.prototype.parse = function(report, rinfo) {
   var deviceSid = report['sid'];
@@ -275,14 +278,14 @@ LightSwitchParser.prototype.parse = function(report, rinfo) {
   }
 }
 
-inherits(LightSwitchParser, BaseParser);
-
 // Duplex light switch data parser
 DuplexLightSwitchParser = function(platform) {
   this.init(platform);
   this.commanders0 = {};
   this.commanders1 = {};
 }
+
+inherits(DuplexLightSwitchParser, BaseParser);
 
 DuplexLightSwitchParser.prototype.parse = function(report, rinfo) {
   var deviceSid = report['sid'];
@@ -323,13 +326,14 @@ DuplexLightSwitchParser.prototype.parseInternal = function(deviceSid, commanders
   return commander;
 }
 
-inherits(DuplexLightSwitchParser, BaseParser);
 
 // Plug data parser
 PlugSwitchParser = function(platform) {
   this.init(platform);
   this.commanders = {};
 }
+
+inherits(PlugSwitchParser, BaseParser);
 
 PlugSwitchParser.prototype.parse = function(report, rinfo) {
   var deviceSid = report['sid'];
@@ -356,7 +360,6 @@ PlugSwitchParser.prototype.parse = function(report, rinfo) {
   }
 }
 
-inherits(PlugSwitchParser, BaseParser);
 
 // Base commander
 BaseCommander = function() {
@@ -388,6 +391,8 @@ LightSwitchCommander = function(platform, deviceSid, deviceModel, switchName) {
   this.switchName = switchName;
 }
 
+inherits(LightSwitchCommander, BaseCommander);
+
 LightSwitchCommander.prototype.send = function(on) {
   // Dont' send duplicate command out.
   if (this.lastValue == on) {
@@ -418,5 +423,3 @@ LightSwitchCommander.prototype.send = function(on) {
   var command = '{"cmd":"write","model":"' + this.deviceModel + '","sid":"' + this.deviceSid + '","data":"{\\"' + this.switchName + '\\":\\"' + (on ? 'on' : 'off') + '\\", \\"key\\": \\"' + key + '\\"}"}';
   this.sendCommand(command);
 }
-
-inherits(LightSwitchCommander, BaseCommander);


### PR DESCRIPTION
Hi @snOOrz thanks for the excellent work! I had some problems running the code I think this is because the parse functions are before the inheritance:

> [10/16/2016, 10:15:24 AM] recv {"cmd":"read_ack","model":"sensor_ht","sid":"158d0001030515","short_id":35054,"data":"{\"temperature\":\"1935\",\"humidity\":\"5912\"}"}(136 bytes) from client 10.0.0.36:9898

>/Users/paul/.nvm/versions/node/v4.6.0/lib/node_modules/homebridge-aqara/lib/AqaraPlatform.js:175
>      this.parsers[model].parse(json, rinfo);
>                          ^
>
>TypeError: this.parsers[model].parse is not a function
>    at AqaraPlatform.parseMessage (/Users/paul/.nvm/versions/node/v4.6.0/lib/node_modules/homebridge-aqara/lib/AqaraPlatform.js:175:27)
>    at emitTwo (events.js:87:13)
>    at Socket.emit (events.js:172:7)
>    at UDP.onMessage (dgram.js:480:8)

Attached is my proposed fix which works for me, if you want anything changed or have any comments please let me know.