### PR TITLE
fix updating temperature to NaN problem

### DIFF
--- a/lib/AqaraAccessoryFactory.js
+++ b/lib/AqaraAccessoryFactory.js
@@ -71,7 +71,7 @@ AqaraAccessoryFactory.prototype.autoRemoveAccessory = function() {
 
 AqaraAccessoryFactory.prototype.setTemperatureAndHumidity = function(gatewaySid, deviceSid, temperature, humidity) {
   // Temperature
-  this.findServiceAndSetValue(
+  isNaN(temperature) || this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
     UUIDGen.generate('Tem' + deviceSid),
@@ -82,7 +82,7 @@ AqaraAccessoryFactory.prototype.setTemperatureAndHumidity = function(gatewaySid,
     null); // No commander
 
   // Humidity
-  this.findServiceAndSetValue(
+  isNaN(humidity) || this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
     UUIDGen.generate('Hum' + deviceSid),


### PR DESCRIPTION
temperature&humidity sensor sometimes reports message actively like this: {"data": {"humidity": x}}, which results in temperature being NaN (in AqaraPlatform.js: var temperature = data['temperature'] / 100.0;)

FYI, the plugin broadcasts the "whois" command every 300 seconds, and the sensor responds passively like this: {"data": {"humidity": x, "temperature": y}}, which is ok