### PR TITLE
Adding sensor name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ Aqara is a ZigBee gateway with a few sensors. Please see the pictures below.
                 ...
             }]
         }
+        
+ If you prefer to see sensor names instead of hex digis as name, add a mapping table to your config.json
+ 
+        {
+            "platforms": [
+            {
+                "platform": "AqaraPlatform",
+                ...
+                "sensor_names": {
+					"74ef":"Kitchen Window"
+                }
+                ...
+            }]
+        }   
 
 ### Run it
 1. From source code

--- a/lib/AqaraAccessoryFactory.js
+++ b/lib/AqaraAccessoryFactory.js
@@ -1,4 +1,5 @@
 var Accessory, PlatformAccessory, Service, Characteristic, UUIDGen, Factory;
+var sensorNames;
 
 module.exports = function(homebridge) {
   Accessory = homebridge.hap.Accessory;
@@ -20,6 +21,11 @@ function AqaraAccessoryFactory(log, config, api) {
   this.gatewaySids = {};
   this.lastGatewayUpdateTime = {};
   this.lastDeviceUpdateTime = {};
+
+  this.SensorNames = {};
+  if( config['sensor_names'] ) {
+    this.sensorNames = config['sensor_names'];
+  }
 }
 
 // Function invoked when homebridge tries to restore cached accessory
@@ -34,9 +40,22 @@ AqaraAccessoryFactory.prototype.configureAccessory = function(accessory) {
   // accessory.updateReachability()
   accessory.reachable = true;
   accessory.on('identify', function(paired, callback) {
-    that.log(accessory.displayName, "Identify!!!");
+    that.log(accessory.displayName + "* Identify!!!" );
     callback();
   });
+
+  // update accessory names from the config:
+  if( this.sensorNames[accessory.displayName] ) {
+     var displayName = this.sensorNames[accessory.displayName];
+     this.log('Resetting saved name ' + accessory.displayName + ' -> ' + displayName );
+     accessory.displayName = displayName;
+     var characteristic = service.getCharacteristic(Characteristic.Name);
+
+     if (characteristic) {
+         // that.log("Set %s %s", serviceName, characteristicValue);
+        characteristic.updateValue(displayName);
+     }
+  }
 
   this.accessories.push(accessory);
   this.lastDeviceUpdateTime[accessory.UUID] = Date.now();
@@ -108,6 +127,8 @@ AqaraAccessoryFactory.prototype.setMotion = function(gatewaySid, deviceSid, moti
 
 // Contact sensor
 AqaraAccessoryFactory.prototype.setContact = function(gatewaySid, deviceSid, contacted) {
+  
+
   this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
@@ -156,6 +177,8 @@ AqaraAccessoryFactory.prototype.getAccessoryModel = function(type) {
     case Service.HumiditySensor:
       return "Humidity Sensor";
     case Service.ContactSensor:
+    case Service.Door:
+    case Service.Window:
       return "Contact Sensor";
     case Service.MotionSensor:
       return "Motion Sensor";
@@ -173,6 +196,10 @@ AqaraAccessoryFactory.prototype.findServiceAndSetValue = function(
 
   // Use last four characters of deviceSid as service name
   var accessoryName = deviceSid.substring(deviceSid.length - 4);
+  if( this.sensorNames[accessoryName] ) {
+    var displayName = this.sensorNames[accessoryName];
+    accessoryName = displayName;
+  } 
   var serviceName = accessoryName;
 
   // Remember gateway/device update time

--- a/lib/AqaraPlatform.js
+++ b/lib/AqaraPlatform.js
@@ -71,6 +71,8 @@ AqaraPlatform.prototype.loadConfig = function(config) {
     // log.debug("Load password %s:%s from config.json file", sid[index], password);
     return passwords;
   }, {});
+
+  this.sensorNames = config['sensor_names'];
 }
 
 AqaraPlatform.prototype.doRestThings = function(api) {


### PR DESCRIPTION
Hi, 

I added support for hardcoding sensor names instead of the last 4 deviceID digits in the config.json so they don't get lost when home kit re-reads the config.

