### PR TITLE
Bugfix for updating sensor names

### DIFF
--- a/lib/AqaraAccessoryFactory.js
+++ b/lib/AqaraAccessoryFactory.js
@@ -22,10 +22,12 @@ function AqaraAccessoryFactory(log, config, api) {
   this.lastGatewayUpdateTime = {};
   this.lastDeviceUpdateTime = {};
 
-  this.SensorNames = {};
-  if( config['sensor_names'] ) {
-    this.sensorNames = config['sensor_names'];
-  }
+  // uuidPrefix is an optional prefix so the UUIDs are bridge-unique.
+  // This allows in an dev environment to expose the Aqara gateway twice without confusing HomeKit  
+  this.uuidPrefix = config.uuidPrefix ? config.uuidPrefix : '';
+
+  // lookup sensornames to more meaningful names...
+  this.sensorNames = config.sensor_names ? config.sensor_names : {};
 }
 
 // Function invoked when homebridge tries to restore cached accessory
@@ -45,16 +47,21 @@ AqaraAccessoryFactory.prototype.configureAccessory = function(accessory) {
   });
 
   // update accessory names from the config:
-  if( this.sensorNames[accessory.displayName] ) {
-     var displayName = this.sensorNames[accessory.displayName];
-     this.log('Resetting saved name ' + accessory.displayName + ' -> ' + displayName );
-     accessory.displayName = displayName;
-     var characteristic = service.getCharacteristic(Characteristic.Name);
+  var currentName = accessory.displayName;
+  var mappedName = this.sensorNames[currentName];
 
-     if (characteristic) {
-         // that.log("Set %s %s", serviceName, characteristicValue);
-        characteristic.updateValue(displayName);
-     }
+  if( mappedName ) {
+     this.log('Resetting saved name ' + currentName + ' -> ' + mappedName );
+     accessory.displayName = mappedName;
+
+     accessory.services.forEach( function( service )  {
+         if( service.displayName == currentName ) {
+           service.displayName = mappedName;
+         } 
+         
+         var nameCharacteristic = service.getCharacteristic(Characteristic.Name);
+         nameCharacteristic.setValue(mappedName);
+     } );
   }
 
   this.accessories.push(accessory);
@@ -93,7 +100,7 @@ AqaraAccessoryFactory.prototype.setTemperatureAndHumidity = function(gatewaySid,
   isNaN(temperature) || this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
-    UUIDGen.generate('Tem' + deviceSid),
+    UUIDGen.generate(this.uuidPrefix + 'Tem' + deviceSid),
     Accessory.Categories.SENSOR,
     Service.TemperatureSensor,
     Characteristic.CurrentTemperature,
@@ -104,7 +111,7 @@ AqaraAccessoryFactory.prototype.setTemperatureAndHumidity = function(gatewaySid,
   isNaN(humidity) || this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
-    UUIDGen.generate('Hum' + deviceSid),
+    UUIDGen.generate(this.uuidPrefix + 'Hum' + deviceSid),
     Accessory.Categories.SENSOR,
     Service.HumiditySensor,
     Characteristic.CurrentRelativeHumidity,
@@ -117,7 +124,7 @@ AqaraAccessoryFactory.prototype.setMotion = function(gatewaySid, deviceSid, moti
   this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
-    UUIDGen.generate('Mot' + deviceSid),
+    UUIDGen.generate(this.uuidPrefix + 'Mot' + deviceSid),
     Accessory.Categories.SENSOR,
     Service.MotionSensor,
     Characteristic.MotionDetected,
@@ -132,7 +139,7 @@ AqaraAccessoryFactory.prototype.setContact = function(gatewaySid, deviceSid, con
   this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
-    UUIDGen.generate('Mag' + deviceSid),
+    UUIDGen.generate(this.uuidPrefix + 'Mag' + deviceSid),
     Accessory.Categories.SENSOR,
     Service.ContactSensor,
     Characteristic.ContactSensorState,
@@ -145,7 +152,7 @@ AqaraAccessoryFactory.prototype.setLightSwitch = function(gatewaySid, deviceSid,
   this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
-    UUIDGen.generate(uuidSeed),
+    UUIDGen.generate(this.uuidPrefix + uuidSeed),
     this.config.fakeLightBulbForLightSwitch ? Accessory.Categories.LIGHTBULB : Accessory.Categories.SWITCH,
     this.config.fakeLightBulbForLightSwitch ? Service.Lightbulb : Service.Switch,
     Characteristic.On,
@@ -158,7 +165,7 @@ AqaraAccessoryFactory.prototype.setPlugSwitch = function(gatewaySid, deviceSid, 
   this.findServiceAndSetValue(
     gatewaySid,
     deviceSid,
-    UUIDGen.generate(uuidSeed),
+    UUIDGen.generate(this.uuidPrefix + uuidSeed),
     Accessory.Categories.OUTLET,
     Service.Outlet,
     Characteristic.On,


### PR DESCRIPTION
Sorry, had to discover that updating sensor names was problematic.

This PR includes: 
* An fix for updating already cached sensor names
* The possibility to add an optional 'uuid prefix' in config.json so HomeKit doesn't get confused with if you add a second home bridge instance mapped to the same Aqara gateway