### PR TITLE
Set reuseAddr for compatibility with other Aqara libraries

### DIFF
--- a/lib/AqaraPlatform.js
+++ b/lib/AqaraPlatform.js
@@ -2,7 +2,10 @@ const dgram = require('dgram');
 const inherits = require('util').inherits;
 const crypto = require('crypto');
 const iv = Buffer.from([0x17, 0x99, 0x6d, 0x09, 0x3d, 0x28, 0xdd, 0xb3, 0xba, 0x69, 0x5a, 0x2e, 0x6f, 0x58, 0x56, 0x2e]);
-const serverSocket = dgram.createSocket('udp4');
+const serverSocket = dgram.createSocket({
+  type: 'udp4',
+  reuseAddr: true
+});
 const multicastAddress = '224.0.0.50';
 const multicastPort = 4321;
 const serverPort = 9898;


### PR DESCRIPTION
This change sets reuseAddr on the UDP socket so that several sockets can
be created bound to port 9898. This allows several libraries (Node or
otherwise) to interact with the Aqara gateway at the same time.